### PR TITLE
Move from JSON to using ast.literal_eval

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python3 -m pip uninstall dictstore -y
+
+python3 setup.py bdist_wheel 
+
+python3 -m pip install dist/dictstore-*.whl

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# create a virtual environment for testing
+
+echo '--------------------------------'
+echo 'Setting Up Virtual Environment'
+echo '--------------------------------'
+
+python3 -m venv testvenv
+
+# activate the virtual environment
+
+source testvenv/bin/activate
+
+# remove dictstore if it already exists
+
+echo '--------------------------'
+echo 'Removing Existing Package'
+echo '--------------------------'
+
+python -m pip uninstall dictstore -y
+
+echo '------------------'
+echo 'Installing Package'
+echo '------------------'
+
+python setup.py install
+
+# run the tests using test.py
+
+echo '------------------'
+echo 'Running Tests'
+echo '------------------'
+
+python tests/test.py

--- a/src/dictstore/exceptions.py
+++ b/src/dictstore/exceptions.py
@@ -38,7 +38,7 @@ class DataStoreFileCorrupted(Exception):
     """
 
     def __init__(self) -> None:
-        self.message = ("The datastore file might be corrupted"
+        self.message = ("The datastore file might be corrupted "
                         "or the contents of the file have been edited manually"
                         )
         super().__init__(self.message)

--- a/src/dictstore/file_handler.py
+++ b/src/dictstore/file_handler.py
@@ -67,11 +67,11 @@ class FileHandler:
         with open(self.file_path, 'r', encoding='utf-8') as data_file:
             self.file_contents = data_file.read()
 
-    def rewrite_to_file(self, string: str) -> None:
-        """Writes the given string to data file"""
+    def rewrite_to_file(self, lines) -> None:
+        """Writes the given lines to data file"""
         with open(self.file_path, 'w', encoding='utf-8') as data_file:
             data_file.write(generate_file_header_string())
-            data_file.write(string)
+            data_file.writelines(lines)
 
     def append_to_file(self, string: str) -> None:
         """Appends the given string to data file"""
@@ -87,4 +87,4 @@ class FileHandler:
         with open(self.file_path, 'r', encoding='utf-8') as data_file:
             data_file.readline()
             data_file.readline()
-            return data_file.read()
+            return data_file.readlines()

--- a/src/dictstore/interface.py
+++ b/src/dictstore/interface.py
@@ -22,7 +22,6 @@ similar to a python dictionary.
 
 
 from typing import Any
-# import json
 import ast
 
 from dictstore.exceptions import DataStoreFileCorrupted

--- a/src/dictstore/interface.py
+++ b/src/dictstore/interface.py
@@ -22,7 +22,8 @@ similar to a python dictionary.
 
 
 from typing import Any
-import json
+# import json
+import ast
 
 from dictstore.exceptions import DataStoreFileCorrupted
 from dictstore.file_handler import FileHandler
@@ -48,24 +49,22 @@ class DictStore:
         # initialize the data file
         self.file_handler = FileHandler(datastore_location)
 
-        # fetch the records from data file
-        json_string = self.file_handler.read_from_file()
+        # fetch the file contents and parse accordingly
+        # parse key and value as JSON objects
 
-        # check if the json string has a trailing comma and remove it
-        if json_string[-1] == ',':
-            json_string = json_string[:-1]
+        data = self.file_handler.read_from_file()
 
-        # add '{' at the start and '}' at the end
-        json_string = '{' + json_string + '}'
+        # check if the number of lines are even
 
-        # convert json string to dictionary
-        try:
-            json_data = json.loads(json_string)
-        except json.decoder.JSONDecodeError as json_decode_error:
-            raise DataStoreFileCorrupted() from json_decode_error
+        if len(data) % 2 != 0:
+            raise DataStoreFileCorrupted()
 
-        # update the in memory dictionary with the JSON data
-        self.in_memory_dictionary.update(json_data)
+        for line_number_of_key in range(0, len(data), 2):
+            key = data[line_number_of_key]
+            key_parsed = ast.literal_eval(key)
+            value = data[line_number_of_key + 1]
+            value_parsed = ast.literal_eval(value)
+            self.in_memory_dictionary[key_parsed] = value_parsed
 
     def __get_sanitised_key(self, key: Any) -> str:
         """
@@ -75,17 +74,17 @@ class DictStore:
         without the '<' and '>' characters
         """
 
-        if isinstance(key, int):
-            return f'<int>{key}'
+        return key
 
-        is_string = isinstance(key, str)
-        is_int_key = '<int>' == key[:5]
-        has_unsupported_chars = '<' in key or '>' in key
-        if (is_string and not has_unsupported_chars) or is_int_key:
-            return key
+    def __get_escaped_string(self, var: Any) -> str:
+        """
+        checks if the given key or value is an integers and adds
+        quotes around the key if it is.
+        """
+        if isinstance(var, str):
+            return '\'' + var + '\''
 
-        print(key, type(key))
-        raise KeyError()
+        return str(var)
 
     def __rewrite_data_file(self) -> None:
         """
@@ -95,11 +94,19 @@ class DictStore:
         to the data file.
         """
 
-        json_string = json.dumps(self.in_memory_dictionary)
+        # convert each record into the desired format
+        # Format: key, json(value)
 
-        self.file_handler.rewrite_to_file(json_string[1:-1] + ',')
+        data_file_cache = []
 
-    def __add_record_to_data_file(self, record: dict) -> None:
+        for key, value in self.in_memory_dictionary.items():
+            print(key, '|', value)
+            data_file_cache.append(self.__get_escaped_string(key) + '\n')
+            data_file_cache.append(self.__get_escaped_string(value) + '\n')
+
+        self.file_handler.rewrite_to_file(data_file_cache)
+
+    def __add_record_to_data_file(self, key, value) -> None:
         """
         converts the given record to JSON string
         removes the '{' and '}' symbols at the start and end
@@ -107,9 +114,10 @@ class DictStore:
         to the end of data file
         """
 
-        json_string = json.dumps(record)
+        data_record_cache = self.__get_escaped_string(key) + '\n'
+        data_record_cache += self.__get_escaped_string(value) + '\n'
 
-        self.file_handler.append_to_file(json_string[1:-1] + ',')
+        self.file_handler.append_to_file(data_record_cache)
 
     # -----------------
     # Read Operations
@@ -156,7 +164,7 @@ class DictStore:
         # add record to the data file
         if self.get(key) is None:
             self.in_memory_dictionary[key] = value
-            self.__add_record_to_data_file({key: value})
+            self.__add_record_to_data_file(key, value)
 
         # if a record exists with the given key
         # add new key-value pair to in memory dictionary

--- a/src/dictstore/interface.py
+++ b/src/dictstore/interface.py
@@ -65,16 +65,6 @@ class DictStore:
             value_parsed = ast.literal_eval(value)
             self.in_memory_dictionary[key_parsed] = value_parsed
 
-    def __get_sanitised_key(self, key: Any) -> str:
-        """
-        checks if the given object is an integer or string.
-        returns the key string if the object is an integer
-        or if the object is a string
-        without the '<' and '>' characters
-        """
-
-        return key
-
     def __get_escaped_string(self, var: Any) -> str:
         """
         checks if the given key or value is an integers and adds
@@ -137,7 +127,6 @@ class DictStore:
         takes a key and returns the value if it exists.
         returns None if the key does not exist.
         """
-        key = self.__get_sanitised_key(key)
 
         return self.in_memory_dictionary.get(key)
 
@@ -156,7 +145,6 @@ class DictStore:
         and updates the value if it already exists
         creates a new record otherwise
         """
-        key = self.__get_sanitised_key(key)
 
         # if there is no record with the given key
         # update the in memory dictionary and
@@ -177,7 +165,6 @@ class DictStore:
         takes a key
         and removes the record if it exists
         """
-        key = self.__get_sanitised_key(key)
 
         # if a record exists with the given key
         # remove it from the in memory dictionary

--- a/src/dictstore/interface.py
+++ b/src/dictstore/interface.py
@@ -67,7 +67,7 @@ class DictStore:
 
     def __get_escaped_string(self, var: Any) -> str:
         """
-        checks if the given key or value is an integers and adds
+        checks if the given key or value is a string and adds
         quotes around the key if it is.
         """
         if isinstance(var, str):
@@ -77,14 +77,15 @@ class DictStore:
 
     def __rewrite_data_file(self) -> None:
         """
-        converts in memory dictionary to JSON string
-        removes the '{' and '}' symbols at the start and end
+        converts in memory dictionary to string
         asks file handler to write the resulting string
         to the data file.
         """
 
         # convert each record into the desired format
-        # Format: key, json(value)
+        # Format:
+        # key \n
+        # json(value) \n
 
         data_file_cache = []
 
@@ -97,8 +98,7 @@ class DictStore:
 
     def __add_record_to_data_file(self, key, value) -> None:
         """
-        converts the given record to JSON string
-        removes the '{' and '}' symbols at the start and end
+        converts the given record to string
         asks file handler to append the resulting string
         to the end of data file
         """

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,12 +1,26 @@
+# Copyright 2021 Sai Sampath Kumar Balivada
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 tests module for dictstore
 """
 
 import unittest
+import os
 from dictstore import file_handler
 import dictstore.exceptions
-
-# TODO: Move each class to a separate module for better maintainability
+from dictstore.interface import DictStore
 
 
 class TestFileHandler(unittest.TestCase):
@@ -20,6 +34,119 @@ class TestFileHandler(unittest.TestCase):
         """
         with self.assertRaises(dictstore.exceptions.InvalidFileExtension):
             file_handler.FileHandler('file_name_without_dictstore_extension')
+
+
+class TestDictStoreKeys(unittest.TestCase):
+    """
+    checks if all types of hashable keys are
+        being accepted and retrieved correctly
+
+            Key Types:
+                Integer
+                Float/Decimal
+                String
+                Integer Tuple
+                String Tuple
+    """
+
+    def __clean_temp_files(self, file_name):
+        """
+        remove data file if already exists
+        """
+        try:
+            os.remove(file_name)
+        except OSError:
+            pass
+
+    def test_integer_key(self):
+        """
+        checks if integer keys are working correctly
+        """
+
+        data_file_name = 'tests/test_integer_key.dictstore'
+
+        self.__clean_temp_files(data_file_name)
+
+        dict_store = DictStore(data_file_name)
+        dict_store[1] = 45
+
+        dict_store = DictStore(data_file_name)
+        self.assertEqual(dict_store[1], 45, "Integer Key")
+
+    def test_float_key(self):
+        """
+        checks if floating point keys are working correctly
+        """
+
+        data_file_name = 'tests/test_float_key.dictstore'
+
+        self.__clean_temp_files(data_file_name)
+
+        dict_store = DictStore(data_file_name)
+        dict_store[1.2] = 45
+
+        dict_store = DictStore(data_file_name)
+        self.assertEqual(dict_store[1.2], 45, "Floating Point Key")
+
+    def test_char_string_key(self):
+        """
+        checks if character string keys are working correctly
+        """
+
+        data_file_name = 'tests/test_char_string_key.dictstore'
+
+        self.__clean_temp_files(data_file_name)
+
+        dict_store = DictStore(data_file_name)
+        dict_store['str'] = 45
+
+        dict_store = DictStore(data_file_name)
+        self.assertEqual(dict_store['str'], 45, "Character String Key")
+
+    def test_integer_string_key(self):
+        """
+        checks if integer string keys are working correctly
+        """
+
+        data_file_name = 'tests/test_integer_string_key.dictstore'
+
+        self.__clean_temp_files(data_file_name)
+
+        dict_store = DictStore(data_file_name)
+        dict_store['2'] = 45
+
+        dict_store = DictStore(data_file_name)
+        self.assertEqual(dict_store['2'], 45, "Integer String Key")
+
+    def test_integer_tuple_key(self):
+        """
+        checks if integer tuple keys are working correctly
+        """
+
+        data_file_name = 'tests/test_integer_tuple_key.dictstore'
+
+        self.__clean_temp_files(data_file_name)
+
+        dict_store = DictStore(data_file_name)
+        dict_store[(1, 2)] = 45
+
+        dict_store = DictStore(data_file_name)
+        self.assertEqual(dict_store[(1, 2)], 45, "Integer Tuple Key")
+
+    def test_string_tuple_key(self):
+        """
+        checks if integer tuple keys are working correctly
+        """
+
+        data_file_name = 'tests/test_string_tuple_key.dictstore'
+
+        self.__clean_temp_files(data_file_name)
+
+        dict_store = DictStore(data_file_name)
+        dict_store[('1', '2')] = 45
+
+        dict_store = DictStore(data_file_name)
+        self.assertEqual(dict_store[('1', '2')], 45, "String Tuple Key")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Change Log:

- created install.sh to aid local installation and
  exploration testing.
- modified run_tests.sh to create a virtual env and run tests.
- fixed space typo in exceptions.py
- moved from using json to ast.literal_eval for consistent and
  better storage and retrieval
- modified file_handler.rewrite_to_file to accept list(str)
  instead of str
- added multiple tests for checking dictstore keys
- removed sanitise_key method as it is no longer needed 
- updated method docstrings and comments